### PR TITLE
Fix date picker sizing

### DIFF
--- a/src/components/DatePickerField.jsx
+++ b/src/components/DatePickerField.jsx
@@ -31,8 +31,8 @@ const DatePickerField = ({ id, label, value, onChange, error, description }) => 
             {selected ? format(selected, 'PPP') : 'Select date'}
           </Button>
         </PopoverTrigger>
-        <PopoverContent 
-          className="p-0 w-auto border-2 border-border shadow-xl backdrop-blur-sm" 
+        <PopoverContent
+          className="p-0 w-72 border-2 border-border shadow-xl backdrop-blur-sm"
           align="start"
           sideOffset={4}
         >
@@ -41,7 +41,7 @@ const DatePickerField = ({ id, label, value, onChange, error, description }) => 
             selected={selected}
             onSelect={(date) => onChange(date ? format(date, 'yyyy-MM-dd') : '')}
             initialFocus
-            className="rounded-lg"
+            className="rounded-lg w-full"
           />
         </PopoverContent>
       </Popover>


### PR DESCRIPTION
## Summary
- ensure date picker popover has consistent width
- let calendar fill popover width for balanced appearance

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b281e37d14832793347bef197a6cf1

## Summary by Sourcery

Ensure date picker popover and calendar components have consistent and balanced width by setting a fixed popover width and making the calendar fill the container.

Bug Fixes:
- Fix inconsistent width of date picker popover.

Enhancements:
- Make calendar component span full width of its popover.